### PR TITLE
Tag the Docker cloud-builder to the latest available version

### DIFF
--- a/terraform/cloud-build/build-docker-image-trigger.yaml
+++ b/terraform/cloud-build/build-docker-image-trigger.yaml
@@ -13,19 +13,19 @@
 # limitations under the License.
 ---
 steps:
-    - name: 'gcr.io/cloud-builders/docker'
+    - name: 'gcr.io/cloud-builders/docker:20.10.3'
       args: ['run', '--privileged', 'linuxkit/binfmt:v0.7']
       id: 'initialize-qemu'
-    - name: 'gcr.io/cloud-builders/docker'
+    - name: 'gcr.io/cloud-builders/docker:20.10.3'
       args: ['buildx', 'create', '--name', 'mybuilder']
       id: 'create-builder'
-    - name: 'gcr.io/cloud-builders/docker'
+    - name: 'gcr.io/cloud-builders/docker:20.10.3'
       args: ['buildx', 'use', 'mybuilder']
       id: 'select-builder'
-    - name: 'gcr.io/cloud-builders/docker'
+    - name: 'gcr.io/cloud-builders/docker:20.10.3'
       args: ['buildx', 'inspect', '--bootstrap']
       id: 'show-target-build-platforms'
-    - name: 'gcr.io/cloud-builders/docker'
+    - name: 'gcr.io/cloud-builders/docker:20.10.3'
       args: ['buildx', 'build', '--platform', '$_DOCKER_BUILDX_PLATFORMS', '-t', 'gcr.io/$PROJECT_ID/test:latest', '--push', '.']
       id: 'build-multi-architecture-container-image'
 options:


### PR DESCRIPTION
This PR ensures that we use a tagged version of the Docker Cloud Builder image.

Fixes #1 

/cc @aebrahim